### PR TITLE
Fix erreur de maj sur la contenance reel d'un asset sur update de la …

### DIFF
--- a/class/ordre_fabrication_asset.class.php
+++ b/class/ordre_fabrication_asset.class.php
@@ -2303,7 +2303,9 @@ class TAssetOFLine extends TObjetStd{
 
                 $qty_to_make_rest-=$qty_to_make_asset;
 
-                $TAsset->contenancereel_value = $qty_to_make_asset;
+//                $TAsset->contenancereel_value = $qty_to_make_asset;
+				// Je force la contenance à 0, car l'appel à la méthode load_asset_type() un peu plus haut init la valeur, de plus cet attribut sera update par stockAsset()
+				$TAsset->contenancereel_value = 0;
                 $TAsset->lot_number = $lot_number;
 
                 if (!empty($conf->global->ASSET_USE_DEFAULT_WAREHOUSE) && empty($fk_entrepot)) $fk_entrepot = $conf->global->ASSET_DEFAULT_WAREHOUSE_ID_TO_MAKE;


### PR DESCRIPTION
…quantité produite depuis un OF Terminé

Il reste une erreur à corriger dans cette méthode (`makeAsset`), si on produit 100 unités puis on corrige la quantité pour 90 et que finalement on c'est trompé dans la saisie et qu'on saisie 92, le fait que le delta soit positif va créer un nouvel asset

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/atm-consulting/dolibarr_module_of/56)
<!-- Reviewable:end -->
