### PR TITLE
Fix tk8163

### DIFF
--- a/admin/of_setup.php
+++ b/admin/of_setup.php
@@ -579,7 +579,7 @@ print '</td></tr>';
 
 $var=!$var;
 print '<tr '.$bc[$var].'>';
-print '<td>'.$langs->trans('OF_CLOSE_TASK_LINKED_TO_PRODUCT_LINKED_TO_SUPPLIER_ORDER_NEED_STT').'</td>';
+print '<td>'.$form->textwithtooltip($langs->trans('OF_CLOSE_TASK_LINKED_TO_PRODUCT_LINKED_TO_SUPPLIER_ORDER_NEED_STT'), $langs->trans('NEED_CONF_OF_CLOSE_TASK_LINKED_TO_PRODUCT_LINKED_TO_SUPPLIER_ORDER'),2,1,img_help(1,'')).'</td>';
 print '<td align="center" width="20">&nbsp;</td>';
 print '<td align="center" width="300">';
 print ajax_constantonoff('OF_CLOSE_TASK_LINKED_TO_PRODUCT_LINKED_TO_SUPPLIER_ORDER_NEED_STT');

--- a/admin/of_setup.php
+++ b/admin/of_setup.php
@@ -579,6 +579,14 @@ print '</td></tr>';
 
 $var=!$var;
 print '<tr '.$bc[$var].'>';
+print '<td>'.$langs->trans('OF_CLOSE_TASK_LINKED_TO_PRODUCT_LINKED_TO_SUPPLIER_ORDER_NEED_STT').'</td>';
+print '<td align="center" width="20">&nbsp;</td>';
+print '<td align="center" width="300">';
+print ajax_constantonoff('OF_CLOSE_TASK_LINKED_TO_PRODUCT_LINKED_TO_SUPPLIER_ORDER_NEED_STT');
+print '</td></tr>';
+
+$var=!$var;
+print '<tr '.$bc[$var].'>';
 print '<td>'.$langs->trans('OF_CLOSE_OF_ON_CLOSE_ALL_TASK').'</td>';
 print '<td align="center" width="20">&nbsp;</td>';
 print '<td align="center" width="300">';

--- a/core/triggers/interface_99_modof_oftrigger.class.php
+++ b/core/triggers/interface_99_modof_oftrigger.class.php
@@ -297,20 +297,21 @@ class Interfaceoftrigger
 										foreach($of->TAssetWorkstationOF as &$wsof) {
 
 										    if($ws->id == $wsof->fk_asset_workstation && $wsof->fk_project_task>0) {
+										        
 										        if ($wsof->nb_days_before_beginning>0) {
 
     												$wsof->nb_days_before_beginning = 0;
     												$wsof->save($PDOdb);
     										    }
-
+    										    
     										    if(!empty($conf->global->OF_CLOSE_TASK_LINKED_TO_PRODUCT_LINKED_TO_SUPPLIER_ORDER)) {
 
     										        dol_include_once('/projet/class/task.class.php');
-
+    										        
     										        foreach($object->lines as &$line) {
 
-    										            if($line->fk_product == $ofLine->fk_product) {
-
+    										            if($line->fk_product == $ofLine->fk_product && ($wsof->type == 'STT' || empty($conf->global->OF_CLOSE_TASK_LINKED_TO_PRODUCT_LINKED_TO_SUPPLIER_ORDER_NEED_STT)) ) {
+    										                
     										                $projectTask = new Task($db);
     										                $projectTask->fetch($wsof->fk_project_task);
     										                $projectTask->progress = 100;

--- a/langs/fr_FR/of.lang
+++ b/langs/fr_FR/of.lang
@@ -328,6 +328,7 @@ OrderLinePrice=Prix de la ligne
 CannotLoadThisOrderAreYouInTheGoodEntity=Impossible de charger la commande. Etes-vous sur la bonne entité de travail ?
 ErrorOFFromAnotherEntity=OF créé dans une autre entité
 OF_CLOSE_TASK_LINKED_TO_PRODUCT_LINKED_TO_SUPPLIER_ORDER=Clore les tâches liée à un produit en commande fournisseur à la réception de cette dernière
+OF_CLOSE_TASK_LINKED_TO_PRODUCT_LINKED_TO_SUPPLIER_ORDER_NEED_STT=Clore les tâches liée à un produit en commande fournisseur à la réception de cette dernière seulement si le poste de travail associé à la tâche est de type "Sous-traitance"
 
 InssuficienteAssetContenanceToUsedInOF=Contenu insuffisant dans l'équipement %s
 InssuficienteAssetContenanceToAddFromOF=Contenance de l'équipement %s dépassée

--- a/langs/fr_FR/of.lang
+++ b/langs/fr_FR/of.lang
@@ -328,8 +328,8 @@ OrderLinePrice=Prix de la ligne
 CannotLoadThisOrderAreYouInTheGoodEntity=Impossible de charger la commande. Etes-vous sur la bonne entité de travail ?
 ErrorOFFromAnotherEntity=OF créé dans une autre entité
 OF_CLOSE_TASK_LINKED_TO_PRODUCT_LINKED_TO_SUPPLIER_ORDER=Clore les tâches liée à un produit en commande fournisseur à la réception de cette dernière
-OF_CLOSE_TASK_LINKED_TO_PRODUCT_LINKED_TO_SUPPLIER_ORDER_NEED_STT=Clore les tâches liée à un produit en commande fournisseur à la réception de cette dernière seulement si le poste de travail associé à la tâche est de type "Sous-traitance"
-
+OF_CLOSE_TASK_LINKED_TO_PRODUCT_LINKED_TO_SUPPLIER_ORDER_NEED_STT=Clore les tâches liée seulement si le poste de travail associé à la tâche est de type "Sous-traitance"
+NEED_CONF_OF_CLOSE_TASK_LINKED_TO_PRODUCT_LINKED_TO_SUPPLIER_ORDER=Nécessite l'activation de la configuration "Clore les tâches liée à un produit en commande fournisseur à la réception de cette dernière"
 InssuficienteAssetContenanceToUsedInOF=Contenu insuffisant dans l'équipement %s
 InssuficienteAssetContenanceToAddFromOF=Contenance de l'équipement %s dépassée
 OF_CLOSE_OF_ON_CLOSE_ALL_TASK=Clore l'OF à la cloture de la dernière tâche de ce dernier


### PR DESCRIPTION
Modifier le comportement qui fait actuellement que la tâche passe à 100 % lors de la réception d'une commande fournisseur. 

Faire en sorte que cela ne se fasse que si le poste de travail associé à la tâche est de type "Sous-traitance".

du coup ajout d'une conf

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/atm-consulting/dolibarr_module_of/68)
<!-- Reviewable:end -->
