### PR TITLE
(Quentin) FIX pmp price was never used when creating of

### DIFF
--- a/class/ordre_fabrication_asset.class.php
+++ b/class/ordre_fabrication_asset.class.php
@@ -2406,8 +2406,13 @@ class TAssetOFLine extends TObjetStd{
 					$nd = new TNomenclatureDet();
 					$nd->fk_product = $this->fk_product;
 					$PDOdb=new TPDOdb();
-					$this->pmp = $nd->getSupplierPrice($PDOdb, $this->qty>0 ? $this->qty : 1, true, true);
-
+					if(!empty($conf->global->NOMENCLATURE_COST_TYPE) && $conf->global->NOMENCLATURE_COST_TYPE == 'pmp'){
+			        		//sélectionne le pmp si renseigné
+			        		$this->pmp = $nd->getPMPPrice();
+			        		if(empty($this->pmp)) $this->pmp = $nd->getSupplierPrice($PDOdb, $this->qty>0 ? $this->qty : 1, true, true);
+			    		}else {
+						$this->pmp = $nd->getSupplierPrice($PDOdb, $this->qty>0 ? $this->qty : 1, true, true);
+					}
 				}
 				else {
 					$this->product = new Product($db);


### PR DESCRIPTION
Cas client : 

Un client X utilisait OF sans nomenclature avec les produits virtuels (Les ofs utilisaient donc le pmp produit)
Suite à leur demande je dois les passer sur nomenclature, or, lors de cette conversion les résultats étaient différents car l'OF prenait le meilleur prix d'achat fournisseur plutot que le pmp du produit, et ça peu importe la conf de nomenclature.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/atm-consulting/dolibarr_module_of/72)
<!-- Reviewable:end -->
