### PR TITLE
New focus on add product and hidden conf

### DIFF
--- a/fiche_of.php
+++ b/fiche_of.php
@@ -1102,8 +1102,38 @@ function _fiche(&$PDOdb, &$assetOf, $mode='edit',$fk_product_to_add=0,$fk_nomenc
 	if (empty($_REQUEST['fk_product']))
 	{
 		ob_start();
-		$doliform->select_produits('','fk_product','',$conf->product->limit_size,0,-1,2,'',3,array(),0,0,0,'minwidth300');
-		$select_product = ob_get_clean();	
+		$doliform->select_produits('','fk_product','',$conf->product->limit_size,0,-1,2,'',3,array(),0,$conf->global->OF_ONE_SHOOT_ADD_PRODUCT?1:0,0,'minwidth300');
+		$select_product = ob_get_clean();
+
+		?>
+            <script type="text/javascript">
+                    if ($('*:focus').length == 0) {
+                        $(document).one('keypress',function(e) {
+                            $('#fk_product').select2('open');
+                        });
+                    }
+            </script>
+        <?php
+        if(!empty($conf->global->OF_ONE_SHOOT_ADD_PRODUCT)){ //conf caché
+        ?>
+            <script type="text/javascript">
+                $(document).ready(function(){
+                    $('#fk_product').on("select2:select", function(e) {
+                        let contentBtAdd = '<?php echo $langs->trans('BtAdd'); ?>';
+                        let select = $("select[name='fk_nomenclature'] option");
+                        if(select.length){//check if element exist
+                            if(select.length <= 1 ){ //s'il n'y a qu'une seule nomenclature ou moins on ajoute la ligne à la volée
+                                $("button:contains('"+contentBtAdd+"')").click();
+                            }
+                        }else {
+
+                             $("button:contains('"+contentBtAdd+"')").click();
+                        }
+                    });
+                });
+            </script>
+        <?php
+        }
 	}
 	
 	$Tid = array();

--- a/fiche_of.php
+++ b/fiche_of.php
@@ -1106,31 +1106,34 @@ function _fiche(&$PDOdb, &$assetOf, $mode='edit',$fk_product_to_add=0,$fk_nomenc
 		$select_product = ob_get_clean();
 
 		?>
-            <script type="text/javascript">
-                    if ($('*:focus').length == 0) {
-                        $(document).one('keypress',function(e) {
-                            $('#fk_product').select2('open');
-                        });
-                    }
-            </script>
+
         <?php
         if(!empty($conf->global->OF_ONE_SHOOT_ADD_PRODUCT)){ //conf caché
         ?>
             <script type="text/javascript">
+
+
+                $(document).on('keypress',function(e) {
+                       if ($('input:focus').length == 0) {
+                            $('#fk_product').select2('open');
+                        }
+                });
+
                 $(document).ready(function(){
+
+                    let contentBtAdd = '<?php echo $langs->trans('BtAdd'); ?>';
                     $('#fk_product').on("select2:select", function(e) {
-                        let contentBtAdd = '<?php echo $langs->trans('BtAdd'); ?>';
                         let select = $("select[name='fk_nomenclature'] option");
                         if(select.length){//check if element exist
                             if(select.length <= 1 ){ //s'il n'y a qu'une seule nomenclature ou moins on ajoute la ligne à la volée
                                 $("button:contains('"+contentBtAdd+"')").click();
                             }
                         }else {
-
                              $("button:contains('"+contentBtAdd+"')").click();
                         }
                     });
                 });
+
             </script>
         <?php
         }

--- a/fiche_of.php
+++ b/fiche_of.php
@@ -1102,7 +1102,7 @@ function _fiche(&$PDOdb, &$assetOf, $mode='edit',$fk_product_to_add=0,$fk_nomenc
 	if (empty($_REQUEST['fk_product']))
 	{
 		ob_start();
-		$doliform->select_produits('','fk_product','',$conf->product->limit_size,0,-1,2,'',3,array(),0,$conf->global->OF_ONE_SHOOT_ADD_PRODUCT?1:0,0,'minwidth300');
+		$doliform->select_produits('','fk_product','',$conf->product->limit_size,0,-1,2,'',3,array(),0,1,0,'minwidth300');
 		$select_product = ob_get_clean();
 
 		?>

--- a/fiche_of.php
+++ b/fiche_of.php
@@ -1106,19 +1106,18 @@ function _fiche(&$PDOdb, &$assetOf, $mode='edit',$fk_product_to_add=0,$fk_nomenc
 		$select_product = ob_get_clean();
 
 		?>
-
-        <?php
-        if(!empty($conf->global->OF_ONE_SHOOT_ADD_PRODUCT)){ //conf caché
-        ?>
-            <script type="text/javascript">
-
-
+		<script type="text/javascript">
                 $(document).on('keypress',function(e) {
                        if ($('input:focus').length == 0) {
                             $('#fk_product').select2('open');
                         }
                 });
+        </script>
+        <?php
+        if(!empty($conf->global->OF_ONE_SHOOT_ADD_PRODUCT)){ //conf caché
+        ?>
 
+<script type="text/javascript">
                 $(document).ready(function(){
 
                     let contentBtAdd = '<?php echo $langs->trans('BtAdd'); ?>';

--- a/fiche_of.php
+++ b/fiche_of.php
@@ -1117,7 +1117,7 @@ function _fiche(&$PDOdb, &$assetOf, $mode='edit',$fk_product_to_add=0,$fk_nomenc
         if(!empty($conf->global->OF_ONE_SHOOT_ADD_PRODUCT)){ //conf caché
         ?>
 
-<script type="text/javascript">
+            <script type="text/javascript">
                 $(document).ready(function(){
 
                     let contentBtAdd = '<?php echo $langs->trans('BtAdd'); ?>';

--- a/tpl/fiche_of.tpl.php
+++ b/tpl/fiche_of.tpl.php
@@ -595,9 +595,9 @@
 			$(".btnaddproduct" ).unbind().click(function() {
 				var type = $(this).attr('rel');
 				var idassetOf = $(this).attr('id_assetOf');
-                [onshow;block=begin;when [conf.global.OF_ONE_SHOOT_ADD_PRODUCT]=='1']
-                    $('#fk_product').val(null).trigger('change');//reinit le select
-                [onshow;block=end]
+
+                $('#fk_product').val(null).trigger('change');//reinit le select
+
 				$( "#dialog" ).dialog({
 					show: {
 						effect: "blind",

--- a/tpl/fiche_of.tpl.php
+++ b/tpl/fiche_of.tpl.php
@@ -595,7 +595,9 @@
 			$(".btnaddproduct" ).unbind().click(function() {
 				var type = $(this).attr('rel');
 				var idassetOf = $(this).attr('id_assetOf');
-
+                [onshow;block=begin;when [conf.global.OF_ONE_SHOOT_ADD_PRODUCT]=='1']
+                    $('#fk_product').val(null).trigger('change');//reinit le select
+                [onshow;block=end]
 				$( "#dialog" ).dialog({
 					show: {
 						effect: "blind",


### PR DESCRIPTION
S'il n'y aucun input focus, et que nous scannons un code barre, le produit va automatiquement se sélectionné(s'il existe) et si la conf caché est activé, on ajoute la ligne s'il n'y qu'une ou aucune nomenclature liée à ce produit