### PR TITLE
FIX : Ajout config pour génération PDF/ODT

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 
 
 ## Version 2.12
+- FIX : Conf pour génération des models d'OF sur validation (car ne fonctionne que si les models sont compat standard Dolibarr *02/12/2021* - 2.12.3
 - FIX : Ne  pas créer les lignes à 0 de qté *02/12/2021* - 2.12.2
 - FIX : Button cancel sur stock transfert non fonctionnel depuis OF *30/11/2021* - 2.12.1
 - NEW : Ordre des composants dans OF en fonction de la ref produit + Affichage référence lors de transfert de stock *30/11/2021* - 2.12.0

--- a/class/ordre_fabrication_asset.class.php
+++ b/class/ordre_fabrication_asset.class.php
@@ -517,7 +517,11 @@ class TAssetOF extends TObjetStd{
                 $this->calculTaskDates(); // calcul des dates pour respecter l'enchainement des dates
             }
 
-			$this->generateDocument('', $langs);
+            if($conf->global->OF_FORCE_GENERATE_PDF_ON_VALID){
+                // cette conf ne fonctionne qu'avec les models compatibles standard Dolibarr
+                // elle fait planter les génération en TBS odt car fonctionne avec un vieux sytème tout pérave
+                $this->generateDocument('', $langs);
+            }
 
 			return 1;
 		}

--- a/core/modules/modof.class.php
+++ b/core/modules/modof.class.php
@@ -60,7 +60,7 @@ class modof extends DolibarrModules
 		// Module description, used if translation string 'ModuleXXXDesc' not found (where XXX is value of numeric property 'numero' of module)
 		$this->description = "Ordres de fabrication: management of manufacturing orders";
 		// Possible values for version are: 'development', 'experimental', 'dolibarr' or version
-		$this->version = '2.12.2';
+		$this->version = '2.12.3';
 		// Key used in llx_const table to save module status enabled/disabled (where MYMODULE is value of property name of module in uppercase)
 		$this->const_name = 'MAIN_MODULE_'.strtoupper($this->name);
 		// Where to store the module in setup page (0=common,1=interface,2=others,3=very specific)


### PR DESCRIPTION
### FIX : Ajout config pour génération PDF/ODT

La génération des modèles PDF sur validation des OF ne fonctionne qu'avec les modèles compatible standard (pas ceux crée par le module OF d'ATM), donc : 
Ajout d'une configuration permettant d'activer la génération des modèles sur validation des OFs
