### PR TITLE
FIX : Amélioration de conf "Prix d'achat/revient suggéré par défaut" du module nomenclature

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 ## UNRELEASED
 
 ## Version 2.13
-- FIX : Ajout du traitement de la conf "Prix d'achat/revient suggéré par défaut" du module Nomenclature
+- FIX : Ajout du traitement de la conf "Prix d'achat/revient suggéré par défaut" du module Nomenclature *04/02/2022* - 2.13.3
 - FIX : conf to not update pmp *26/01/2022* - 2.13.2
 - FIX : The click on the gear with a ToMake qty of zero now decreases the quantities of the needed products *05/01/2022* - 2.13.1
 - NEW : Configuration permettant de tenir compte des ofs brouillon dans le stock théorique + quelques fix liés au stock théorique *17/12/2021* - 2.13.0

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 ## UNRELEASED
 
 ## Version 2.13
+- FIX : Ajout du traitement de la conf "Prix d'achat/revient suggéré par défaut" du module Nomenclature
 - FIX : conf to not update pmp *26/01/2022* - 2.13.2
 - FIX : The click on the gear with a ToMake qty of zero now decreases the quantities of the needed products *05/01/2022* - 2.13.1
 - NEW : Configuration permettant de tenir compte des ofs brouillon dans le stock théorique + quelques fix liés au stock théorique *17/12/2021* - 2.13.0

--- a/class/ordre_fabrication_asset.class.php
+++ b/class/ordre_fabrication_asset.class.php
@@ -3518,12 +3518,12 @@ class TAssetOFLine extends TObjetStd{
 					if(!empty($conf->global->NOMENCLATURE_COST_TYPE) && $conf->global->NOMENCLATURE_COST_TYPE == 'pmp'){
 						//sélectionne le pmp si renseigné
 						$this->pmp = $nd->getPMPPrice();
-						if(empty($this->pmp)) $this->pmp = $nd->getSupplierPrice($PDOdb, $this->qty>0 ? $this->qty : 1, true,true,false,true);
+						if(empty($this->pmp) || $this->pmp == 0) $this->pmp = $nd->getSupplierPrice($PDOdb, $this->qty>0 ? $this->qty : 1, true,true,false,true);
 					} elseif(!empty($conf->global->NOMENCLATURE_COST_TYPE) && $conf->global->NOMENCLATURE_COST_TYPE == 'costprice') {
 						// sélectionne le prix de revient sur la fiche produit si renseigné, sinon sélectionne le PMP si renseigné, sinon sélectionne le meilleur prix fournisseur
 						$this->pmp = $nd->getCostPrice();
 						if(empty($this->pmp)) $this->pmp = $nd->getPMPPrice();
-						if(empty($this->pmp)) $this->pmp = $nd->getSupplierPrice($PDOdb, $this->qty>0 ? $this->qty : 1, true,true,false,true);
+						if(empty($this->pmp) || $this->pmp == 0) $this->pmp = $nd->getSupplierPrice($PDOdb, $this->qty>0 ? $this->qty : 1, true,true,false,true);
 					} else {
 						$this->pmp = $nd->getSupplierPrice($PDOdb, $this->qty>0 ? $this->qty : 1, true,true,false,true);
 					}

--- a/class/ordre_fabrication_asset.class.php
+++ b/class/ordre_fabrication_asset.class.php
@@ -3516,11 +3516,16 @@ class TAssetOFLine extends TObjetStd{
 					$nd->fk_product = $this->fk_product;
 					$PDOdb=new TPDOdb();
 					if(!empty($conf->global->NOMENCLATURE_COST_TYPE) && $conf->global->NOMENCLATURE_COST_TYPE == 'pmp'){
-			        		//sélectionne le pmp si renseigné
-			        		$this->pmp = $nd->getPMPPrice();
-			        		if(empty($this->pmp)) $this->pmp = $nd->getSupplierPrice($PDOdb, $this->qty>0 ? $this->qty : 1, true, true);
-			    		}else {
-						$this->pmp = $nd->getSupplierPrice($PDOdb, $this->qty>0 ? $this->qty : 1, true, true);
+						//sélectionne le pmp si renseigné
+						$this->pmp = $nd->getPMPPrice();
+						if(empty($this->pmp)) $this->pmp = $nd->getSupplierPrice($PDOdb, $this->qty>0 ? $this->qty : 1, true,true,false,true);
+					} elseif(!empty($conf->global->NOMENCLATURE_COST_TYPE) && $conf->global->NOMENCLATURE_COST_TYPE == 'costprice') {
+						// sélectionne le prix de revient sur la fiche produit si renseigné, sinon sélectionne le PMP si renseigné, sinon sélectionne le meilleur prix fournisseur
+						$this->pmp = $nd->getCostPrice();
+						if(empty($this->pmp)) $this->pmp = $nd->getPMPPrice();
+						if(empty($this->pmp)) $this->pmp = $nd->getSupplierPrice($PDOdb, $this->qty>0 ? $this->qty : 1, true,true,false,true);
+					} else {
+						$this->pmp = $nd->getSupplierPrice($PDOdb, $this->qty>0 ? $this->qty : 1, true,true,false,true);
 					}
 				}
 				else {

--- a/core/modules/modof.class.php
+++ b/core/modules/modof.class.php
@@ -60,7 +60,7 @@ class modof extends DolibarrModules
 		// Module description, used if translation string 'ModuleXXXDesc' not found (where XXX is value of numeric property 'numero' of module)
 		$this->description = "Ordres de fabrication: management of manufacturing orders";
 		// Possible values for version are: 'development', 'experimental', 'dolibarr' or version
-		$this->version = '2.13.2';
+		$this->version = '2.13.3';
 		// Key used in llx_const table to save module status enabled/disabled (where MYMODULE is value of property name of module in uppercase)
 		$this->const_name = 'MAIN_MODULE_'.strtoupper($this->name);
 		// Where to store the module in setup page (0=common,1=interface,2=others,3=very specific)

--- a/liste_of.php
+++ b/liste_of.php
@@ -768,8 +768,12 @@ if ($resql)
             if(! $i) $totalarray['nbfield']++;
         }
 
-        // Extra fields
-//        include DOL_DOCUMENT_ROOT.'/core/tpl/extrafields_list_array_fields.tpl.php';
+        //Le fichier n'existe pas avant la version 13
+        if(floatval(DOL_VERSION) > 12){
+			// Extra fields
+			include DOL_DOCUMENT_ROOT.'/core/tpl/extrafields_list_array_fields.tpl.php';
+        }
+
         // Fields from hook
         $parameters = ['arrayfields' => $arrayfields, 'obj' => $obj];
         $reshook = $hookmanager->executeHooks('printFieldListValue', $parameters);    // Note that $action and $object may have been modified by hook

--- a/liste_of.php
+++ b/liste_of.php
@@ -769,7 +769,7 @@ if ($resql)
         }
 
         // Extra fields
-        include DOL_DOCUMENT_ROOT.'/core/tpl/extrafields_list_array_fields.tpl.php';
+//        include DOL_DOCUMENT_ROOT.'/core/tpl/extrafields_list_array_fields.tpl.php';
         // Fields from hook
         $parameters = ['arrayfields' => $arrayfields, 'obj' => $obj];
         $reshook = $hookmanager->executeHooks('printFieldListValue', $parameters);    // Note that $action and $object may have been modified by hook


### PR DESCRIPTION
##FIX : Amélioration de conf "Prix d'achat/revient suggéré par défaut" du module nomenclature

L'option "Prix de revient si défini sur la fiche produit ou PMP si défini ou meilleur prix fournisseur" de la conf  "Prix d'achat/revient suggéré par défaut" ne fonctionnait pas.

DONE : 
- Ajout du traitement de l'option "Prix de revient si défini sur la fiche produit ou PMP si défini ou meilleur prix fournisseur" de la conf
- Suppression de l'inclusion d'une classe inutilisée et non présente qui provoquait un warning
