### PR TITLE
FIX : Retour de l'espace

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 ## UNRELEASED
 
 ## Version 2.13
+- FIX : Lors de la mise à jour des quantités via l'engrenage, la quantités était constamment remise à 0 *10/02/2022* - 2.13.3
 - FIX : conf to not update pmp *26/01/2022* - 2.13.2
 - FIX : The click on the gear with a ToMake qty of zero now decreases the quantities of the needed products *05/01/2022* - 2.13.1
 - NEW : Configuration permettant de tenir compte des ofs brouillon dans le stock théorique + quelques fix liés au stock théorique *17/12/2021* - 2.13.0

--- a/core/modules/modof.class.php
+++ b/core/modules/modof.class.php
@@ -60,7 +60,7 @@ class modof extends DolibarrModules
 		// Module description, used if translation string 'ModuleXXXDesc' not found (where XXX is value of numeric property 'numero' of module)
 		$this->description = "Ordres de fabrication: management of manufacturing orders";
 		// Possible values for version are: 'development', 'experimental', 'dolibarr' or version
-		$this->version = '2.13.2';
+		$this->version = '2.13.3';
 		// Key used in llx_const table to save module status enabled/disabled (where MYMODULE is value of property name of module in uppercase)
 		$this->const_name = 'MAIN_MODULE_'.strtoupper($this->name);
 		// Where to store the module in setup page (0=common,1=interface,2=others,3=very specific)

--- a/script/interface.php
+++ b/script/interface.php
@@ -283,7 +283,12 @@ function _updateQtyMaking(&$PDOdb, $fk_of,$idLine,$action,$qty, $qty_used, $qty_
         if($action == 'updateqty') $res = $of->updateToMakeLineQty($PDOdb, $idLine, $qty);
         else if($action == 'updateqty_usernocompliant') $res = $of->updateUsedNonCompliantLineQty($PDOdb, $idLine, $qty_used, $qty_non_compliant);
     } else {
-        $res = $of->updateNomenclatureToMakeQty($PDOdb, floatval($qty), floatval($qty_used), floatval($qty_non_compliant), $idLine, false, true);
+		$qty = $qty === '' ? $assetOfLine->qty : $qty;
+		if($qty == 0){
+			$res = $of->updateNomenclatureToMakeQty($PDOdb, floatval($qty), floatval($qty_used), floatval($qty_non_compliant), $idLine, false, true);
+		} else {
+			$res = $of->updateNomenclatureToMakeQty($PDOdb, floatval($qty), floatval($qty_used), floatval($qty_non_compliant), $idLine);
+		}
     }
 	return $res;
 }

--- a/tpl/fiche_of.tpl.php
+++ b/tpl/fiche_of.tpl.php
@@ -148,7 +148,7 @@
 									[onshow;block=end]
 										[TTomake.extrafields;strconv=no]
 									</td>
-									<td valign="top">[TTomake.qty;strconv=no]</td>
+									<td valign="top" id="qty">[TTomake.qty;strconv=no]</td>
 									<td valign="top">[TTomake.qty_used;strconv=no]</td>
 									<td width="30%" valign="top">[TTomake.fk_product_fournisseur_price;strconv=no]</td>
                                     [onshow;block=begin;when [conf.global.OF_MANAGE_NON_COMPLIANT;noerr]==1]
@@ -864,10 +864,10 @@
 
 			[onshow;block=begin;when [view.mode]!='view']
 
-				if ($(btnadd).attr('statut') == 'DRAFT' || $(btnadd).attr('statut') == 'OPEN') {
-					qty = $(btnadd).closest('tr').find("input[id*='[qty]']").val();
-					qty_used = $(btnadd).closest('tr').find("input[id*='[qty_used]']").val();
-					qty_non_compliant = $(btnadd).closest('tr').find("input[id*='[qty_non_compliant]']").val();
+            if ($(btnadd).attr('statut') == 'DRAFT' || $(btnadd).attr('statut') == 'OPEN') {
+                qty = $(btnadd).closest('tr').find("input[id*='[qty]']").val();
+                qty_used = $(btnadd).closest('tr').find("input[id*='[qty_used]']").val();
+                qty_non_compliant = $(btnadd).closest('tr').find("input[id*='[qty_non_compliant]']").val();
 
 					if ($(btnadd).attr('statut') == 'DRAFT') {
 						action = 'updateqty';

--- a/tpl/fiche_of.tpl.php
+++ b/tpl/fiche_of.tpl.php
@@ -148,7 +148,7 @@
 									[onshow;block=end]
 										[TTomake.extrafields;strconv=no]
 									</td>
-									<td valign="top" id="qty">[TTomake.qty;strconv=no]</td>
+									<td valign="top">[TTomake.qty;strconv=no]</td>
 									<td valign="top">[TTomake.qty_used;strconv=no]</td>
 									<td width="30%" valign="top">[TTomake.fk_product_fournisseur_price;strconv=no]</td>
                                     [onshow;block=begin;when [conf.global.OF_MANAGE_NON_COMPLIANT;noerr]==1]


### PR DESCRIPTION
## FIX : Retour de l'espace

Lors de la mise à jour des quantités (via un clic sur l'engrenage), la quantité du/des produit/s "A FAIRE" était passée à 0 si le statut de l'OF était "En cours de production"

A quoi c'est du ? 
Champs "qty", contenant la valeur permettant ensuite de calculer les quantités nécessaire passe d'input à td après le passage au statut "En cours de production"
La valeur n'était donc plus récupérée et était donc séttée à 0.


Done : 
- Ajout d'un test, si la quantité est vide, on lui set la valeur présente en base 
- Si la quantité est égale à 0 on lance la fonction de mise à jour des quantités avec le paramètre showempty 