### PR TITLE
Bugfix for adding products via product combo list

### DIFF
--- a/tpl/fiche_of.tpl.php
+++ b/tpl/fiche_of.tpl.php
@@ -8,7 +8,7 @@
 	[onshow;block=end]
 
 	.ui-autocomplete {
-		z-index:999;
+		z-index:1003;
 	}
 </style>
 	<div class="OFMaster" assetOf_id="[assetOf.id]" fk_assetOf_parent="[assetOf.fk_assetOf_parent]">


### PR DESCRIPTION
Bugfix:

Currently it is only possible to add a product via dropdown to the order. But if you change the product settings in admin area to product combo list, which is loaded if you type in 1 to 3 chars (depending on config) then the add screen overlaps the product combo list. This makes it impossible to select something from the product combo list and the whole module cannot be used anymore. This is due to an wrong z-index. The product add dialog has a z-index of 1002 and the combo list of 999. Therefore the combo list z index needs to be changed to at least 1003.