### PR TITLE
wrong parameter usage in mb_strrpos

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 
 ## UNRELEASED
 
+- FIX : wrong parameter usage of mb_strrpos in of.lib.php
+
 ## Version 2.13
 
 - FIX : Fatal sur page d'admin des modèles de PDF provoquée par un ancien exemple de modèle obsolète. - *30/03/2023* - 2.13.10

--- a/lib/of.lib.php
+++ b/lib/of.lib.php
@@ -621,7 +621,7 @@ function get_next_value_PDOdb(TPDOdb $db,$mask,$table,$field,$where='',$objsoc='
     // Define $sqlstring
     if (function_exists('mb_strrpos'))
     {
-        $posnumstart=mb_strrpos($maskwithnocode,$maskcounter, 'UTF-8');
+        $posnumstart=mb_strrpos($maskwithnocode,$maskcounter,0,'UTF-8');
     }
     else
     {


### PR DESCRIPTION
customer order cannot be validated due to wrong parameter usage in mb_strrpos. 3rd parameter needs to be integer, but was a string. Only occurs if php module mbstrings is activated.