### PR TITLE
bugfix: creation of production orders not done if customer order is validated through api

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 
 ## UNRELEASED
 
-
+- FIX : creation of production orders not done if customer order is validated through api *11/07/2023*
 
 ## Version 2.14
 

--- a/core/triggers/interface_99_modof_oftrigger.class.php
+++ b/core/triggers/interface_99_modof_oftrigger.class.php
@@ -170,7 +170,7 @@ class Interfaceoftrigger
 						if($prod->stock_reel < $line->qty) {
 
 							$assetOF = new TAssetOF;
-							$assetOF->fk_commande = $_REQUEST['id'];
+							$assetOF->fk_commande = $object->id;
 							$assetOF->fk_soc = $object->socid;
 							if(!empty($object->date_livraison)) $assetOF->date_besoin = $object->date_livraison;
 							$assetOF->addLine($PDOdb, $line->fk_product, 'TO_MAKE', $line->qty,0, '',0,$line->id);


### PR DESCRIPTION
issue is caused as the trigger checks the array $_request to fetch to customer order number. Instead it should be fetched from $object->id.